### PR TITLE
Temporary fix for the windows issue with .deleteonexit()

### DIFF
--- a/src/main/java/com/superzanti/serversync/SyncClientConnection.java
+++ b/src/main/java/com/superzanti/serversync/SyncClientConnection.java
@@ -221,15 +221,18 @@ public class SyncClientConnection implements Runnable{
 						ServerSyncRegistry.logger.info("Ignoring: " + singleFile.replace('\\', '/'));
 					}else{
 						if(doesExist.equalsIgnoreCase("false")){
-							ServerSyncRegistry.logger.info(singleFile.replace('\\', '/') + " Does not match... Deleting...");
+							String replacedString = singleFile.replace('\\', '/');
+							ServerSyncRegistry.logger.info(replacedString + " Does not match... Deleting...");
 							SyncClient.updateScreenWorking((int)(5+(currentPercent/percentScale)),"Deleting client's " + singleFile.replace('\\', '/'));
-							File deleteMe = new File(singleFile.replace('\\', '/'));
+							
+							File deleteMe = new File("./config/serversync/delete/" + replacedString.replace("/", "_$_"));
+							
 							deleteMe.getParentFile().mkdirs();
 							FileOutputStream wr = new FileOutputStream(deleteMe);
 							wr.write("D".getBytes(), 0, 1);
 							wr.flush();
 							wr.close();
-							deleteMe.deleteOnExit();
+							//deleteMe.deleteOnExit();
 							updateHappened = true;
 						}
 						//reinitConn();


### PR DESCRIPTION
Saves a reference file in config/serversync that is used to delete the
specified mods/configs when minecraft is loaded next.
Rather dirty as I could not find a way to get forge to restart its
Loader so the game needs to be terminated before FML complains about
missing the deleted mods, which in turn requires the user to restart
minecraft again without any real prompt to do so.