### PR TITLE
Fix path separator problem on MacOS and linux

### DIFF
--- a/src/main/java/com/superzanti/serversync/ServerSync.java
+++ b/src/main/java/com/superzanti/serversync/ServerSync.java
@@ -14,6 +14,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -22,6 +23,7 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 @Command(name = "ServerSync", mixinStandardHelpOptions = true, version = RefStrings.VERSION, description = "A utility for synchronizing a server<->client style game.")
 public class ServerSync implements Callable<Integer> {
@@ -92,7 +94,7 @@ public class ServerSync implements Callable<Integer> {
             SyncConfig.getConfig().SERVER_PORT = serverPort;
         }
         if (ignorePatterns != null) {
-            SyncConfig.getConfig().FILE_IGNORE_LIST = Arrays.asList(ignorePatterns);
+            SyncConfig.getConfig().FILE_IGNORE_LIST = Arrays.stream(ignorePatterns).map(s -> s.replace("/", File.separator).replace("\\", File.separator)).collect(Collectors.toList());
         }
 
         try {

--- a/src/main/java/com/superzanti/serversync/client/Mode2Sync.java
+++ b/src/main/java/com/superzanti/serversync/client/Mode2Sync.java
@@ -73,7 +73,7 @@ public class Mode2Sync implements Runnable {
         List<Path> files = manifest.files.stream().map(FileEntry::resolvePath).collect(Collectors.toList());
         for (DirectoryEntry dir : manifest.directories) {
             if (dir.mode == EDirectoryMode.mirror) {
-                Path dirPath = ServerSync.rootDir.resolve(dir.path);
+                Path dirPath = ServerSync.rootDir.resolve(dir.getLocalPath());
                 if (Files.notExists(dirPath)) {
                     // Can happen if a directory is configured to be managed but all of its files are ignored
                     continue;

--- a/src/main/java/com/superzanti/serversync/files/DirectoryEntry.java
+++ b/src/main/java/com/superzanti/serversync/files/DirectoryEntry.java
@@ -3,6 +3,7 @@ package com.superzanti.serversync.files;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 
+import java.io.File;
 import java.io.Serializable;
 
 public class DirectoryEntry implements Serializable {
@@ -12,6 +13,10 @@ public class DirectoryEntry implements Serializable {
     public DirectoryEntry(String path, EDirectoryMode mode) {
         this.path = path;
         this.mode = mode;
+    }
+
+    public String getLocalPath() {
+        return path.replace("/", File.separator).replace("\\", File.separator);
     }
 
     public JsonObject toJson() {

--- a/src/main/java/com/superzanti/serversync/files/FileEntry.java
+++ b/src/main/java/com/superzanti/serversync/files/FileEntry.java
@@ -1,5 +1,6 @@
 package com.superzanti.serversync.files;
 
+import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -46,10 +47,12 @@ public class FileEntry implements Serializable {
     }
 
     public Path resolvePath() {
-        if ("".equals(redirectTo)) {
-            return new PathBuilder().add(path).toPath();
+        String localPath=path.replace("/", File.separator).replace("\\", File.separator);
+        String localRedirect=redirectTo.replace("/", File.separator).replace("\\", File.separator);
+        if ("".equals(localRedirect)) {
+            return new PathBuilder().add(localPath).toPath();
         }
-        return new PathBuilder().add(redirectTo).add(Paths.get(path).getFileName()).toPath();
+        return new PathBuilder().add(localRedirect).add(Paths.get(localPath).getFileName()).toPath();
     }
 
     @Override


### PR DESCRIPTION
A better implement is to use a link-list for representing the path, but is working in current structure.  