### PR TITLE
Change hashing to ignore line feed differences between windows and linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+src/test/resources/hash_lf.txt text eol=lf
+src/test/resources/hash_crlf.txt text eol=crlf

--- a/src/main/java/com/superzanti/serversync/files/FileHash.java
+++ b/src/main/java/com/superzanti/serversync/files/FileHash.java
@@ -3,7 +3,11 @@ package com.superzanti.serversync.files;
 import com.superzanti.serversync.util.Logger;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestInputStream;
@@ -11,12 +15,19 @@ import java.security.MessageDigest;
 
 public class FileHash {
     public static String hashFile(Path file) {
-        try (
+        try {
+            InputStream stream = null;
+            if( FileHash.isBinaryFile(file) ){
+                stream = Files.newInputStream(file);
+            }else{
+                stream = new ByteArrayInputStream(String.join("", Files.readAllLines(file, StandardCharsets.UTF_8)).getBytes());
+            }
+
             DigestInputStream in = new DigestInputStream(
-                new BufferedInputStream(Files.newInputStream(file)),
+                new BufferedInputStream(stream),
                 MessageDigest.getInstance("SHA-256")
-            )
-        ) {
+            );
+
             byte[] buffer = new byte[8192];
             while (in.read(buffer) > -1) { }
             return String.format("%064x", new BigInteger(1, in.getMessageDigest().digest()));
@@ -25,5 +36,18 @@ public class FileHash {
             Logger.debug(e);
         }
         return "";
+    }
+
+    private static boolean isBinaryFile(Path f) throws IOException {
+        String type = Files.probeContentType(f);
+        if (type == null) {
+            //type couldn't be determined, assume binary
+            return true;
+        } else if (type.startsWith("text")) {
+            return false;
+        } else {
+            //type isn't text
+            return true;
+        }
     }
 }

--- a/src/test/java/com/superzanti/serversync/LineFeedTest.java
+++ b/src/test/java/com/superzanti/serversync/LineFeedTest.java
@@ -1,0 +1,25 @@
+package com.superzanti.serversync;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.superzanti.serversync.files.FileHash;
+import com.superzanti.serversync.util.Logger;
+
+class LineFeedTest {
+
+    public LineFeedTest() {
+        Logger.instantiate("test");
+    }
+
+    @Test
+    @DisplayName("Should hash text files ignoring line feeds")
+    void textHash() {
+        String hashLF = FileHash.hashFile(Paths.get(this.getClass().getResource("/hash_lf.txt").getPath()));
+        String hashCRLF = FileHash.hashFile(Paths.get(this.getClass().getResource("/hash_crlf.txt").getPath()));
+        assertEquals(hashLF, hashCRLF);
+    }
+}

--- a/src/test/resources/hash_crlf.txt
+++ b/src/test/resources/hash_crlf.txt
@@ -1,0 +1,1 @@
+This is a file that has specific line endings.

--- a/src/test/resources/hash_lf.txt
+++ b/src/test/resources/hash_lf.txt
@@ -1,0 +1,1 @@
+This is a file that has specific line endings.


### PR DESCRIPTION
This change adds file contents probing to try and guess if a file contains text. If it does, then it opens the file and reads the lines from it instead of opening a binary stream to the file.

The main downside to this change I can see is that it reads the text file into memory and then creates an InputStream over the bytes of the string, which are then read into a buffer to calculate the hash. There may be a cleaner way of implementing this to reduce that memory overhead.

It should fix #286.